### PR TITLE
remove refrences to throwing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Triangle JS Edition
-Make a `Triangle` constructor function that is used to make new triangle instances.  If an instance is created with impossible sides then it `throw` an error.  If not a triangle should know what kind of triangle it is. Keep in mind that the sum of the lengths of any two sides of a triangle always exceeds the length of the third side, a principle known as the _triangle inequality_.
+Make a `Triangle` constructor function that is used to make new triangle instances.  If an instance is created with impossible sides then it is not defined.  If not a triangle should know what kind of triangle it is. Keep in mind that the sum of the lengths of any two sides of a triangle always exceeds the length of the third side, a principle known as the _triangle inequality_.
 
 ## Expectations
   * The constructor function accepts the length of the three sides as three arguments
   * The `#kind` method should return a triangle's kind
-  * The program should raise an error if the triangle cannot exist when a new one is initiated.
+  * The program should return undefined if the triangle cannot exist when a new one is initiated.
 
 ## Tests
 When you finish passing a test, remove the `x` from `xit` to convert it to a runnable test.
@@ -22,6 +22,4 @@ learn
 learn -b
 ```
 
-## Resources
-* [Throw](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw)
-* [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)
+

--- a/spec/triangle.spec.js
+++ b/spec/triangle.spec.js
@@ -55,23 +55,23 @@ describe('Triangle', function() {
 
   describe('Illegal triangles', function() {
     it('test triangles with no size are illegal', function() {
-      expect(function(){ new Triangle(0,0,0) }).toThrow(new TriangleError());
+      expect(function(){ new Triangle(0,0,0) }).not.toBeDefined();
     });
 
     it('triangles with negative sides are illegal', function() {
-      expect(function(){ new Triangle(3,4,-5) }).toThrow(new TriangleError());
+      expect(function(){ new Triangle(3,4,-5) }).not.toBeDefined();
     });
 
     it('triangles violating triangle inequality are illegal', function() {
-      expect(function(){ new Triangle(1,1,3) }).toThrow(new TriangleError());
+      expect(function(){ new Triangle(1,1,3) }).not.toBeDefined();
     });
 
     it('triangles violating triangle inequality are illegal 2', function() {
-      expect(function(){ new Triangle(2,4,2) }).toThrow(new TriangleError());
+      expect(function(){ new Triangle(2,4,2) }).not.toBeDefined();
     });
 
     it('triangles violating triangle inequality are illegal 3', function() {
-      expect(function(){ new Triangle(7,3,2) }).toThrow(new TriangleError());
+      expect(function(){ new Triangle(7,3,2) }).not.toBeDefined();
     });
   });
 


### PR DESCRIPTION
Simplifies the lab to not introduce too many concepts at once.
